### PR TITLE
Use global regex to replace unwanted characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const loadPackage = (pkg) => {
 }
 
 const addPackageToObject = (obj, pkg) => {
-  const variable_friendly_package_name = pkg.name.replace('-', '_').replace('.', '_')
+  const variable_friendly_package_name = pkg.name.replace(/-|\./g, '_')
   logGreen(`Package '${pkg.name}' was loaded and assigned to '${variable_friendly_package_name}' in the current scope`)
   obj[variable_friendly_package_name] = pkg.package
   return obj


### PR DESCRIPTION
This is a small change for replace unwanted characters of the package name, also ensures to replace all the occurrences of the string, so, having this name `"abc-de.ab--.cde-"`:

Before
`"abc_de_ab--.cde-"`
Now
`"abc_de_ab___cde_"`

Thanks for the module!
