### PR TITLE
use a different variable name for lodash in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Downloads the module colors if needed, and starts a nodejs REPL with colors load
 
 Same as above but with many packages in one go!
 
-`trymodule colors=c lodash=_`
+`trymodule colors=c lodash=l`
 
 Assign packages to custom variable names.
 


### PR DESCRIPTION
Using `_` doesn't work on newer versions of node. See https://github.com/nodejs/node/issues/5431

```
❯ node -v   
v6.4.0

~/Desktop master*
❯ trymodule lodash=_
Gonna start a REPL with packages installed and loaded for you
'lodash' was already installed since before!
Package 'lodash' was loaded and assigned to '_' in the current scope
REPL started...
> Expression assignment to _ now disabled.
```
