### PR TITLE
update repl.history from 0.1.3 to 0.1.4 to fix DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "npmi": "^1.0.1",
-    "repl.history": "^0.1.3"
+    "repl.history": "^0.1.4"
   },
   "devDependencies": {
     "standard": "^8.6.0"


### PR DESCRIPTION
This [prevents](https://github.com/tmpvar/repl.history/pull/11) the following warning:

> (node:1234) DeprecationWarning: Calling an asynchronous function without callback is deprecated.