### PR TITLE
allow assignment to underscore (_) without a warning (closes #22)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,7 +88,28 @@ if (hasFlag('--clear')) {
         }
       })
       replHistory(replServer, TRYMODULE_HISTORY_PATH)
-      replServer.context = Object.assign(replServer.context, contextPackages)
+      Object.keys(contextPackages).forEach(as => {
+        var pkg = contextPackages[as]
+        // special-case assignment to _ so that it returns
+        // the required package (e.g. lodash) rather than the
+        // value of the last expression
+        if (as === '_') {
+          Object.defineProperty(replServer.context, as, {
+            configurable: true,
+            enumerable: false,
+            get: function () { return pkg },
+            // allow (temporary) assignment to _:
+            //
+            //     > _ = 42
+            //     42
+            //     > _.each
+            //     [Function: forEach]
+            set: function (val) { return val }
+          })
+        } else {
+          replServer.context[as] = pkg
+        }
+      })
     }
   })
 }

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Downloads the module colors if needed, and starts a nodejs REPL with colors load
 
 Same as above but with many packages in one go!
 
-`trymodule colors=c lodash=l`
+`trymodule colors=c lodash=_`
 
 Assign packages to custom variable names.
 


### PR DESCRIPTION
This uses the [same approach](https://github.com/borisdiakur/n_/blob/v1.4.4/lib/n_.js#L34-L45) as [n_](https://github.com/borisdiakur/n_) (@borisdiakur++) to ensure that _ can safely be assigned and reassigned without:

* a [warning](https://github.com/VictorBjelkholm/trymodule/pull/23): `Expression assignment to _ now disabled.` 
* resulting in _ [becoming undefined](https://github.com/VictorBjelkholm/trymodule/issues/22)

Tested on:

* v4.0.0
* v4.2.1
* v4.8.1
* v6.10.1
* v7.8.0
