### PR TITLE
fix promise detection

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ var replHistory = require('repl.history')
 var vm = require('vm')
 var exec = require('child_process').exec
 var loadPackages = require('./index')
+var isPromise = require('is-promise')
 
 const TRYMODULE_PATH = process.env.TRYMODULE_PATH || path.resolve((os.homedir()), '.trymodule')
 const TRYMODULE_HISTORY_PATH = process.env.TRYMODULE_HISTORY_PATH || path.resolve(TRYMODULE_PATH, 'repl_history')
@@ -74,7 +75,7 @@ if (hasFlag('--clear')) {
           var result = script.runInContext(replServer.context)
           // Some libraries use non-native Promise implementations
           // (ie lib$es6$promise$promise$$Promise)
-          if (result instanceof Promise || (typeof result === 'object' && typeof result.then === 'function')) {
+          if (isPromise(result)) {
             console.log('Returned a Promise. waiting for result...')
             result.then(function (val) {
               callback(null, val)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "colors": "^1.1.2",
+    "is-promise": "^2.1.0",
     "npmi": "^1.0.1",
     "repl.history": "^0.1.3"
   },


### PR DESCRIPTION
Functions are objects and are valid thenables:

> "promise" is an object or function with a then method
> whose behavior conforms to this specification. [1]

This PR uses [is-promise](https://github.com/then/is-promise) to detect promises in a spec-compliant way.

[1] https://promisesaplus.com/#terminology